### PR TITLE
Correct method name for DELETE example

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -197,7 +197,7 @@
                     $crt        = '/path/to/client/crt.pem';
                     $passphrase = 'for-your-key-if-needed';
 
-                    $response = \Httpful\Request::get($uri)
+                    $response = \Httpful\Request::delete($uri)
                         ->authenticateWithCert($cert, $key, $passphrase)
                         ->send();
                 </pre>


### PR DESCRIPTION
The DELETE example specifies `::get`, but it should be `::delete`.
