### PR TITLE
Fix typo in CERT example

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -198,7 +198,7 @@
                     $passphrase = 'for-your-key-if-needed';
 
                     $response = \Httpful\Request::delete($uri)
-                        ->authenticateWithCert($cert, $key, $passphrase)
+                        ->authenticateWithCert($crt, $key, $passphrase)
                         ->send();
                 </pre>
             </div>


### PR DESCRIPTION
`$crt` defined but `$cert` was used